### PR TITLE
Expose port for localhost kafka listener

### DIFF
--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -57,6 +57,7 @@ services:
       # To learn about configuring Kafka for access across networks see
       # https://www.confluent.io/blog/kafka-client-cannot-connect-to-broker-on-aws-on-docker-etc/
       - "9092:9092"
+      - "29092:29092"
       
   identity-api:
     environment:


### PR DESCRIPTION
This enables clients outside of docker network to connect, to test this you can use a tool like kafkacat (kcat).

For example run on the docker compose host machine:

> kafkacat -b localhost:29092 -L